### PR TITLE
Handle null defaultLangSysOffset

### DIFF
--- a/src/lctf.js
+++ b/src/lctf.js
@@ -190,7 +190,9 @@ Typr._lctf.readScriptTable = function(data, offset)
 	var obj = {};
 	
 	var defLangSysOff = bin.readUshort(data, offset);  offset+=2;
-	obj.default = Typr._lctf.readLangSysTable(data, offset0 + defLangSysOff);
+	if (defLangSysOff > 0) {
+		obj.default = Typr._lctf.readLangSysTable(data, offset0 + defLangSysOff);
+	}
 	
 	var langSysCount = bin.readUshort(data, offset);  offset+=2;
 	


### PR DESCRIPTION
I encountered several Noto fonts that have a null (0) defaultLangSysOffset, which is [allowed by the spec](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record). Presumably this means there is no default language system table. I don't know what that means realistically, but a zero offset is nonsensical and can result in errors so it seems reasonable to check for it. FWIW, opentype.js does a similar check.

One of the fonts in question:
https://cdn.jsdelivr.net/gh/lojjic/unicode-font-resolver@v0.2.1/packages/data/font-files/sc-56/sans-serif.normal.400.woff