### PR TITLE
Prevent window to be called

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -58,7 +58,9 @@ Typr._bin = {
 		}
 		return s;
 	},
-	_tdec : typeof window !== 'undefined' && window["TextDecoder"] ? new window["TextDecoder"]() : null,
+	_tdec : function() {
+		return typeof window !== 'undefined' && window["TextDecoder"] ? new window["TextDecoder"]() : null;
+	},
 	readUTF8 : function(buff, p, l) {
 		var tdec = Typr._bin._tdec;
 		if(tdec && p==0 && l==buff.length) return tdec["decode"](buff);


### PR DESCRIPTION
Hello,

When using the Text component of React Drei in a Next.js project, I get this error :
<img width="726" alt="Capture d’écran 2024-02-22 à 15 28 28" src="https://github.com/fredli74/Typr.ts/assets/2699248/caf1e6fd-6d09-4e00-98de-8cf7c189219a">

I invested the problem, and the Text component uses Troika Text, which uses Typr.
To be honest, I don't know really why there is this error, but by encapsulating the `_tdec` result in a function, the error is gone.

Can this change could create some side effect?

Dependency order :
https://github.com/pmndrs/drei
https://github.com/protectwise/troika
https://github.com/protectwise/troika/tree/main/packages/troika-three-text
https://github.com/fredli74/Typr.ts